### PR TITLE
Change Arara link to point to Github repo (#814)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Ansible](http://www.ansible.com/)
 - [AppCleaner](http://freemacsoft.net/appcleaner/)
 - [AppCode](http://www.jetbrains.com/objc/)
-- [Arara](http://cereda.github.io/arara/)
+- [Arara](https://github.com/cereda/arara)
 - [aria2c](http://aria2.sourceforge.net/)
 - [Arm](https://www.atagar.com/arm/)
 - [Artistic Style](http://astyle.sourceforge.net)


### PR DESCRIPTION
Arara website link returns a 404 error. Suggest changing it to point to the Arara Github repo.